### PR TITLE
Added gosensors to glide and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to Lmsensorsbeat.  This Beat strives to pull data from lm-sensors so that you can monitor a variety of I2C/SMBus sensors, such as CPU/motherboard temperatures, fan speeds, voltages, etc.  To run this, you may need to:
 
- 1. Install the lm-sensors library for your distribution
+ 1. Install the lm-sensors library and headers (e.g. libsensors4-dev) for your distribution
  2. Load (modprobe) various kernel modules for your sensors if you don't already.  Once you install lm-sensors, you can usually do this automatically by running the "sensors-detect" command
 
 Ensure that this folder is at the following location:

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,5 @@ import:
   - libbeat/cfgfile
   - libbeat/common
   - libbeat/logp
+- package: github.com/eskibars/gosensors
+  version: 9ae18da104c998f3515b03f115dddf29e73bd193


### PR DESCRIPTION
- Added eskibars/gosensors to glide.yml as this is needed to build lmsensors beat.
- Added requirement for headers package (e.g. libsensors4-dev) to README, as gosensors requires `sensors/sensors.h` and they were missing when only `lm-sensors` was installed. (Ubuntu 14.04 / amd64)
